### PR TITLE
Fix decoder with zero-length buffer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,6 +84,7 @@ Decoder.prototype._transform = function(chunk, enc, cont) {
       return cont()
     }
   }
+  cont()
 }
 
 exports.encode = function(opts) {

--- a/test/decoder.js
+++ b/test/decoder.js
@@ -1,0 +1,11 @@
+/*eslint-env node, mocha */
+
+'use strict'
+
+var frame  = require('../lib')
+
+suite('decoder', function () {
+  test('zero-length', function(done) {
+    frame.decode()._transform(new Buffer(0), 'utf8', done)
+  })
+})


### PR DESCRIPTION
Not seen in practice as Node filters them out but fix in case someone wants to
use the decoder algorithm directly.